### PR TITLE
Persist cache information in localStorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@fortawesome/fontawesome-free-solid": "5.0.8",
     "@fortawesome/vue-fontawesome": "0.0.22",
     "apollo-cache-inmemory": "^1.1.12",
+    "apollo-cache-persist": "^0.1.1",
     "apollo-client": "^2.2.8",
     "apollo-link": "^1.2.1",
     "apollo-link-context": "^1.0.7",

--- a/src/state/apollo.js
+++ b/src/state/apollo.js
@@ -3,6 +3,7 @@ import { split } from 'apollo-link'
 import { HttpLink } from 'apollo-link-http'
 import { createUploadLink } from 'apollo-upload-client'
 import { InMemoryCache } from 'apollo-cache-inmemory'
+import { persistCache } from 'apollo-cache-persist'
 import { SubscriptionClient, MessageTypes } from 'subscriptions-transport-ws'
 import { WebSocketLink } from 'apollo-link-ws'
 import { getMainDefinition } from 'apollo-utilities'
@@ -120,6 +121,12 @@ export default function createApolloClient({
   } else {
     // On the server, we don't want WebSockets and Upload links
   }
+
+  persistCache({
+    cache,
+    storage: window.localStorage,
+    debug: false,
+  })
 
   const stateLink = withClientState({
     cache,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,6 +1355,10 @@ apollo-cache-inmemory@^1.1.12:
     apollo-utilities "^1.0.11"
     graphql-anywhere "^4.1.8"
 
+apollo-cache-persist@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/apollo-cache-persist/-/apollo-cache-persist-0.1.1.tgz#e6cfe1983b998982a679aaf05241d3ed395edb1e"
+
 apollo-cache@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.1.7.tgz#5817018a2fbfc05a21ba319bd17a3e7538110cc5"


### PR DESCRIPTION
Persisting the apollo cache information in localStorage will allow the app to remember local data such as the logged in user across different windows.