### PR TITLE
update path to README

### DIFF
--- a/_start.js
+++ b/_start.js
@@ -19,8 +19,8 @@ const compareUrl = `https://github.com/frandiox/vue-enterprise-boilerplate/compa
 const startNote = `**You diverged from the boilerplate on ${divergeDate}. See [what's been added](${compareUrl}) since then.**`
 
 const newReadmeContent = fs
-  .readFileSync(path.join(__dirname, 'README.md'))
+  .readFileSync(path.join(__dirname, 'docs/README.md'))
   .toString()
   .replace(ciBadge, startNote)
 
-fs.writeFileSync(path.join(__dirname, 'README.md'), newReadmeContent)
+fs.writeFileSync(path.join(__dirname, 'docs/README.md'), newReadmeContent)


### PR DESCRIPTION
when running __start.js we get an error: 
```Error: ENOENT: no such file or directory, open '.../vue-graphql-enterprise-boilerplate/README.md'```
file readme path is: docs/README.md
or, maybe, we can move README.md to root 