### PR TITLE
fix passing option to dev:front

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "npm-run-all --parallel dev:back dev:front",
+    "dev": "npm-run-all --parallel dev:back \"dev:front {@}\" --",
     "dev:front": "vue-cli-service serve",
     "dev:back": "cd server && yarn start",
     "build": "vue-cli-service build",


### PR DESCRIPTION
From docs: # Launch the dev server and automatically open it in
# your default browser when ready
yarn dev --open

in such case we get:
yarn run v1.7.0
$ npm-run-all --parallel dev:back dev:front --open
ERROR: Invalid Option: --open
error Command failed with exit code 1.

this fix pass options from dev script to dev:front(vue-cli-service)