### PR TITLE
fix graphQL

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -24,6 +24,9 @@ const server = new GraphQLServer({
     ...req,
     db,
   }),
+  resolverValidationOptions: {
+    requireResolversForResolveType: false,
+  },
 })
 
 // Verify and expose token information in req.user


### PR DESCRIPTION
on empty project run yarn dev:back and:

yarn run v1.7.0
$ cd server && yarn start
warning package.json: No license field
$ nodemon -e js,json,graphql,gql -x node src/index.js
[nodemon] 1.17.5
[nodemon] to restart at any time, enter `rs`
[nodemon] watching: *.*
[nodemon] starting `node src/index.js`
Type "Node" is missing a "resolveType" resolver. Pass false into "resolverValidationOptions.requireResolversForResolveType" to disable this warning.
events.js:183
      throw er; // Unhandled 'error' event
      ^

Error: listen EADDRINUSE :::4000
    at Object._errnoException (util.js:992:11)
    at _exceptionWithHostPort (util.js:1014:20)
    at Server.setupListenHandle [as _listen2] (net.js:1355:14)
    at listenInCluster (net.js:1396:12)
    at Server.listen (net.js:1480:7)
    at /home/andrey/WebstormProjects/plan-my-trip/node_modules/graphql-yoga/dist/index.js:334:28
    at new Promise (<anonymous>)
    at GraphQLServer.start (/home/andrey/WebstormProjects/plan-my-trip/node_modules/graphql-yoga/dist/index.js:332:16)
    at Object.<anonymous> (/home/andrey/WebstormProjects/plan-my-trip/server/src/index.js:46:8)
    at Module._compile (module.js:652:30)
[nodemon] app crashed - waiting for file changes before starting...